### PR TITLE
Show conversion info in a more compressed format

### DIFF
--- a/components/ConvertForm/ConvertForm.js
+++ b/components/ConvertForm/ConvertForm.js
@@ -157,7 +157,7 @@ function ConvertForm() {
               disabled={true}
             />
             <LabelWithOverlay
-              label={`${selectedOption === 0 ?  `1 wxDAI = ${pricePerUnitReceived} ${bonded.symbol}` : `1 testTEC = ${pricePerUnitReceived} ${collateral.symbol}`}  `}
+              label={`${selectedOption === 0 ?  `1 ${collateral.symbol} = ${pricePerUnitReceived} ${bonded.symbol}` : `1 ${bonded.symbol} = ${pricePerUnitReceived} ${collateral.symbol}`}  `}
               description={`
               ${selectedOption === 0 ? `Entry tribute (${entryTribute}%) = ${inputAmountRetained} ${collateral.symbol}` : `Exit tribute (${exitTribute}%) = ${inputAmountRetained} ${bonded.symbol}`}  
               \n Minimum received (with slippage): ${selectedOption === 0 ? inputMinWithSlippage + " " + bonded.symbol : inputMinWithSlippage + " " + collateral.symbol}

--- a/components/ConvertForm/ConvertForm.js
+++ b/components/ConvertForm/ConvertForm.js
@@ -31,6 +31,7 @@ function ConvertForm() {
   const [messageChecked, setMeessageChecked] = useState(false)
   const {
     amountSource,
+    amountRecipient,
     amountMinWithSlippage,
     bindOtherInput,
     bondingPriceLoading,
@@ -41,7 +42,9 @@ function ConvertForm() {
     inputMinWithSlippage,
     resetInputs,
     entryTribute,
-    exitTribute,    
+    exitTribute, 
+    pricePerUnitReceived, 
+    inputAmountRetained, 
   } = useConvertInputs(options[selectedOption], toBonded)
   const [tokenBalance, spendableBalance] = useTokenBalance(options[selectedOption])
 
@@ -154,18 +157,10 @@ function ConvertForm() {
               disabled={true}
             />
             <LabelWithOverlay
-              label={`${selectedOption === 0 ? `Entry tribute is: ${entryTribute}%` : `Exit tribute is: ${exitTribute}%`}`}
-              description={`Amount before tribute: ${selectedOption === 0 ? inputValueRecipient + " "+ options[1] : inputValueRecipient + " " + options[0]}`}
-              overlayPlacement="top"
-            />
-            <LabelWithOverlay
-              label={`Estimated minimum received (with slippage): ${selectedOption === 0 ? inputMinWithSlippage + " "+ options[1] : inputMinWithSlippage + " " + options[0]}`}
-              description={`This tool uses a bonding curve to convert ${collateral.symbol} into ${bonded.symbol} and
-                      back at a pre-defined rate. The price is calculated by an
-                      automated market maker smart contract that defines a
-                      relationship between token price and token supply. ${selectedOption === 0 ? `You can
-                      also convert wxDAI into DAI using the xDAI bridge.` : `You can also convert ${bonded.symbol}
-                      into other tokens on Honeyswap.`}
+              label={`${selectedOption === 0 ?  `1 wxDAI = ${pricePerUnitReceived} testTEC` : `1 testTEC = ${pricePerUnitReceived} wxDAI`}  `}
+              description={`
+              ${selectedOption === 0 ? `Entry tribute (${entryTribute}%) = ${inputAmountRetained} wxDAI` : `Exit tribute (${exitTribute}%) = ${inputAmountRetained} wxDAI`}  
+              \n Minimum received (with slippage): ${selectedOption === 0 ? inputMinWithSlippage + " "+ options[1] : inputMinWithSlippage + " " + options[0]}
               `}
 
               overlayPlacement="top"

--- a/components/ConvertForm/ConvertForm.js
+++ b/components/ConvertForm/ConvertForm.js
@@ -157,10 +157,10 @@ function ConvertForm() {
               disabled={true}
             />
             <LabelWithOverlay
-              label={`${selectedOption === 0 ?  `1 wxDAI = ${pricePerUnitReceived} testTEC` : `1 testTEC = ${pricePerUnitReceived} wxDAI`}  `}
+              label={`${selectedOption === 0 ?  `1 wxDAI = ${pricePerUnitReceived} ${bonded.symbol}` : `1 testTEC = ${pricePerUnitReceived} ${collateral.symbol}`}  `}
               description={`
-              ${selectedOption === 0 ? `Entry tribute (${entryTribute}%) = ${inputAmountRetained} wxDAI` : `Exit tribute (${exitTribute}%) = ${inputAmountRetained} wxDAI`}  
-              \n Minimum received (with slippage): ${selectedOption === 0 ? inputMinWithSlippage + " "+ options[1] : inputMinWithSlippage + " " + options[0]}
+              ${selectedOption === 0 ? `Entry tribute (${entryTribute}%) = ${inputAmountRetained} ${collateral.symbol}` : `Exit tribute (${exitTribute}%) = ${inputAmountRetained} ${bonded.symbol}`}  
+              \n Minimum received (with slippage): ${selectedOption === 0 ? inputMinWithSlippage + " " + bonded.symbol : inputMinWithSlippage + " " + collateral.symbol}
               `}
 
               overlayPlacement="top"

--- a/components/ConvertForm/useConvertInputs.js
+++ b/components/ConvertForm/useConvertInputs.js
@@ -90,24 +90,6 @@ export function useConvertInputs(otherSymbol, toBonded = true) {
     const receivedWithSlippage = estReceived.mul(100 - maxSlippagePct).div(100)
 
     const singleUnit = (amountSource.isZero()  ? 0 : estReceived/amountSource)
-
-    /*console.log(estReceived)
-    console.log(amountSource)
-    console.log("Is Zero? "+ amountSource.isZero())
-    if (!amountSource.isZero()){
-      console.log("Division with BigNum: " + estReceived.div(amountSource))
-      console.log("Normal division: " + estReceived/amountSource)
-    }
-    
-    console.log("singleUnit: " + singleUnit)
-    console.log("Parsed Single Unit: " + parseUnits(singleUnit.toString())) //This returns an error while converting
-    */
-    setPricePerUnitReceived(
-      //formatUnits(parseUnits(singleUnit.toString()), { digits: bondedDecimals, truncateToDecimalPlace: 16, replaceZeroBy: 0})
-      singleUnit
-      )
-
-    //console.log("pricePerUnitReceived: " + pricePerUnitReceived)
     
     setAmountRecipient(
       amount
@@ -120,6 +102,9 @@ export function useConvertInputs(otherSymbol, toBonded = true) {
     )
     setInputAmountRetained(
       formatUnits(amountRetained, { digits: bondedDecimals, truncateToDecimalPlace: 8 , replaceZeroBy: 0})
+    )
+    setPricePerUnitReceived(
+      singleUnit
     )
     setAmountMinWithSlippage(
       receivedWithSlippage

--- a/components/ConvertForm/useConvertInputs.js
+++ b/components/ConvertForm/useConvertInputs.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { bigNum } from 'lib/utils'
-import { useBondingCurvePrice, useTokenDecimals, getTributePcts } from 'lib/web3-contracts'
+import { useBondingCurvePrice, useTokenDecimals, useTributePcts } from 'lib/web3-contracts'
 import { formatUnits, parseUnits } from 'lib/web3-utils'
 
 import { bonded } from '../../config'
@@ -44,7 +44,7 @@ export function useConvertInputs(otherSymbol, toBonded = true) {
   } = useBondingCurvePrice(amountSource, toBonded)
   const bondedDecimals = useTokenDecimals(bonded.symbol)
   const otherDecimals = useTokenDecimals(otherSymbol)
-  const [entryTribute, exitTribute] = getTributePcts() 
+  const [entryTribute, exitTribute] = useTributePcts() 
 
   // convertFromBonded is used as a toggle to execute a conversion to or from Bonded.
   const [convertFromBonded, setConvertFromBonded] = useState(false)
@@ -86,10 +86,10 @@ export function useConvertInputs(otherSymbol, toBonded = true) {
     const maxSlippagePct = 1 //slippage hardcoded at 1% for now, can be made changeable in the future
 
     const estReceived = amount.mul(100 - applicableTribute).div(100)
-    const amountRetained = amount.mul(applicableTribute).div(100) 
+    const amountRetained = amountSource.mul(applicableTribute).div(100) 
     const receivedWithSlippage = estReceived.mul(100 - maxSlippagePct).div(100)
 
-    const singleUnit = (amountSource.isZero()  ? 0 : estReceived/amountSource)
+    const singleUnit = (amount.isZero()  ? 0 : estReceived/amountSource)
     
     setAmountRecipient(
       amount
@@ -110,7 +110,7 @@ export function useConvertInputs(otherSymbol, toBonded = true) {
       receivedWithSlippage
     )
     setInputMinWithSlippage(
-      formatUnits(receivedWithSlippage, { digits: bondedDecimals, truncateToDecimalPlace: 8 })
+      formatUnits(receivedWithSlippage, { digits: bondedDecimals, truncateToDecimalPlace: 8, replaceZeroBy: 0 })
     )
 
   }, [

--- a/lib/web3-contracts.js
+++ b/lib/web3-contracts.js
@@ -74,7 +74,7 @@ export function useConnectorWeight() {
 }
 
 //returns the tribute percentages as a number between 0 an 100
-export function getTributePcts(){
+export function useTributePcts(){
   const marketMakerContract = useKnownContract('MARKET_MAKER')
 
   const [entryTribute, setEntryTribute] = useState(0)


### PR DESCRIPTION
Should close #47  
The interface now only shows how much you get for 1 unit of the supplied token, and hides the tribute etc. in the tooltip.